### PR TITLE
Updating driver to support `embedded-hal`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,9 @@ description = "I2C driver for the Si7021 hygrometer and thermometer"
 documentation = "https://docs.rs/si7021"
 repository = "https://github.com/klemens/si7021-rs"
 readme = "README.md"
-categories = ["embedded", "hardware-support"]
+categories = ["embedded", "hardware-support", "no-std"]
+keywords = ["si7021", "embedded-hal-driver", "driver", "thermometer", "hygrometer"]
 license = "Apache-2.0/MIT"
 
 [dependencies]
-embedded-hal = "0.2.3"
+embedded-hal = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,4 @@ categories = ["embedded", "hardware-support"]
 license = "Apache-2.0/MIT"
 
 [dependencies]
-byteorder = "1"
 embedded-hal = "0.2.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "si7021"
+edition = "2018"
 version = "0.2.0"
 authors = ["Klemens Schölhorn <klemens@schoelhorn.eu>"]
 description = "I2C driver for the Si7021 hygrometer and thermometer"
@@ -11,5 +12,4 @@ license = "Apache-2.0/MIT"
 
 [dependencies]
 byteorder = "1"
-i2cdev = "0.4.1"
-i2csensors = "0.1.3"
+embedded-hal = "0.2.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 //! I²C driver for the Silicon Labs [Si7021] hygrometer and thermometer.
 //!
 //! [Si7021]: https://www.silabs.com/documents/public/data-sheets/Si7021-A20.pdf

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 //!
 //! [Si7021]: https://www.silabs.com/documents/public/data-sheets/Si7021-A20.pdf
 
-use byteorder::{BigEndian, ByteOrder};
 use embedded_hal::blocking::i2c::WriteRead;
 
 /// Standard I²C address of the Si7021: `0x40`
@@ -41,7 +40,7 @@ impl<T> Si7021<T>
     fn read_word(&mut self, command: u8) -> Result<u16, T::Error> {
         let mut buf = [0u8; 2];
         self.device.write_read(SI7021_I2C_ADDRESS, &[command], &mut buf)?;
-        Ok(BigEndian::read_u16(&buf))
+        Ok(u16::from_be_bytes(buf))
     }
 
     pub fn relative_humidity(&mut self) -> Result<f32, T::Error> {


### PR DESCRIPTION
This PR refactors the driver to support the `embedded-hal`. The device can still be used on Linux through use of the `linux-embedded-hal`. I removed the old `Thermometer` and `Hygrometer` trait implementations because I do not think they are widely adopted or standardized yet.

I originally wrote this code ~6 years ago and recently picked up the project again, so I figured I'd open this PR for feedback.

This fixes #1 

---

As an aside, if you do not want to maintain this driver anymore, it would always be welcome at https://github.com/rust-embedded-community :)